### PR TITLE
Add KIF project to a local group within XCode.

### DIFF
--- a/sample.xcodeproj/project.pbxproj
+++ b/sample.xcodeproj/project.pbxproj
@@ -18,6 +18,41 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		5AE506481C23608700B2442A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5AE506401C23608700B2442A /* KIF.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EABD46AA1857A0C700A5F081;
+			remoteInfo = KIF;
+		};
+		5AE5064A1C23608700B2442A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5AE506401C23608700B2442A /* KIF.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EB60ECC1177F8C83005A041A;
+			remoteInfo = "Test Host";
+		};
+		5AE5064C1C23608700B2442A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5AE506401C23608700B2442A /* KIF.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EABD46CD1857A0F300A5F081;
+			remoteInfo = "KIF Tests";
+		};
+		5AE5064E1C23608700B2442A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5AE506401C23608700B2442A /* KIF.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9CC9673B1AD4B1B600576D13;
+			remoteInfo = KIFFramework;
+		};
+		5AE506501C23609700B2442A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5AE506401C23608700B2442A /* KIF.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = EABD46791857A0C700A5F081;
+			remoteInfo = KIF;
+		};
 		88A25F791C2352C900EB212A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 88A25F571C2352C900EB212A /* Project object */;
@@ -28,6 +63,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5AE506401C23608700B2442A /* KIF.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = KIF.xcodeproj; path = sampleTests/KIF/KIF.xcodeproj; sourceTree = "<group>"; };
 		88A25F5F1C2352C900EB212A /* sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = sample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		88A25F631C2352C900EB212A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		88A25F651C2352C900EB212A /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -64,6 +100,25 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5AE5063F1C23607300B2442A /* TestFrameworks */ = {
+			isa = PBXGroup;
+			children = (
+				5AE506401C23608700B2442A /* KIF.xcodeproj */,
+			);
+			name = TestFrameworks;
+			sourceTree = "<group>";
+		};
+		5AE506411C23608700B2442A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5AE506491C23608700B2442A /* libKIF.a */,
+				5AE5064B1C23608700B2442A /* Test Host.app */,
+				5AE5064D1C23608700B2442A /* KIF Tests - XCTest.xctest */,
+				5AE5064F1C23608700B2442A /* KIF.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		88A25F561C2352C900EB212A = {
 			isa = PBXGroup;
 			children = (
@@ -71,6 +126,7 @@
 				88A25F871C23539700EB212A /* libKIF.a */,
 				88A25F611C2352C900EB212A /* sample */,
 				88A25F7B1C2352C900EB212A /* sampleTests */,
+				5AE5063F1C23607300B2442A /* TestFrameworks */,
 				88A25F601C2352C900EB212A /* Products */,
 			);
 			sourceTree = "<group>";
@@ -147,6 +203,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				5AE506511C23609700B2442A /* PBXTargetDependency */,
 				88A25F7A1C2352C900EB212A /* PBXTargetDependency */,
 			);
 			name = sampleTests;
@@ -183,6 +240,12 @@
 			mainGroup = 88A25F561C2352C900EB212A;
 			productRefGroup = 88A25F601C2352C900EB212A /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 5AE506411C23608700B2442A /* Products */;
+					ProjectRef = 5AE506401C23608700B2442A /* KIF.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				88A25F5E1C2352C900EB212A /* sample */,
@@ -190,6 +253,37 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		5AE506491C23608700B2442A /* libKIF.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libKIF.a;
+			remoteRef = 5AE506481C23608700B2442A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		5AE5064B1C23608700B2442A /* Test Host.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = "Test Host.app";
+			remoteRef = 5AE5064A1C23608700B2442A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		5AE5064D1C23608700B2442A /* KIF Tests - XCTest.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "KIF Tests - XCTest.xctest";
+			remoteRef = 5AE5064C1C23608700B2442A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		5AE5064F1C23608700B2442A /* KIF.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = KIF.framework;
+			remoteRef = 5AE5064E1C23608700B2442A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		88A25F5D1C2352C900EB212A /* Resources */ = {
@@ -232,6 +326,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		5AE506511C23609700B2442A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = KIF;
+			targetProxy = 5AE506501C23609700B2442A /* PBXContainerItemProxy */;
+		};
 		88A25F7A1C2352C900EB212A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 88A25F5E1C2352C900EB212A /* sample */;

--- a/sampleTests/KIF/KIF.xcodeproj/xcuserdata/mlupo.xcuserdatad/xcschemes/KIF Documentation.xcscheme
+++ b/sampleTests/KIF/KIF.xcodeproj/xcuserdata/mlupo.xcuserdatad/xcschemes/KIF Documentation.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A88930091685088F00FC7C63"
+               BuildableName = "KIF Documentation"
+               BlueprintName = "KIF Documentation"
+               ReferencedContainer = "container:KIF.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A88930091685088F00FC7C63"
+            BuildableName = "KIF Documentation"
+            BlueprintName = "KIF Documentation"
+            ReferencedContainer = "container:KIF.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A88930091685088F00FC7C63"
+            BuildableName = "KIF Documentation"
+            BlueprintName = "KIF Documentation"
+            ReferencedContainer = "container:KIF.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/sampleTests/KIF/KIF.xcodeproj/xcuserdata/mlupo.xcuserdatad/xcschemes/Test Host.xcscheme
+++ b/sampleTests/KIF/KIF.xcodeproj/xcuserdata/mlupo.xcuserdatad/xcschemes/Test Host.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EB60ECC0177F8C83005A041A"
+               BuildableName = "Test Host.app"
+               BlueprintName = "Test Host"
+               ReferencedContainer = "container:KIF.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EB60ECC0177F8C83005A041A"
+            BuildableName = "Test Host.app"
+            BlueprintName = "Test Host"
+            ReferencedContainer = "container:KIF.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EB60ECC0177F8C83005A041A"
+            BuildableName = "Test Host.app"
+            BlueprintName = "Test Host"
+            ReferencedContainer = "container:KIF.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EB60ECC0177F8C83005A041A"
+            BuildableName = "Test Host.app"
+            BlueprintName = "Test Host"
+            ReferencedContainer = "container:KIF.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/sampleTests/KIF/KIF.xcodeproj/xcuserdata/mlupo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/sampleTests/KIF/KIF.xcodeproj/xcuserdata/mlupo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>KIF Documentation.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>4</integer>
+		</dict>
+		<key>KIF.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+		<key>KIFFramework.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
+		</dict>
+		<key>Test Host.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>5</integer>
+		</dict>
+	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>9CC9673A1AD4B1B600576D13</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>A88930091685088F00FC7C63</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>EABD46791857A0C700A5F081</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>EABD46AD1857A0F300A5F081</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>EB60ECC0177F8C83005A041A</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
Added KIF as a test target in build settings tab. 
Added a group (a.k.a folder) called TestFrameworks within the XCode IDE to contain the KIF target (Find KIF in local Finder, drag into this new group).
Went into the Build settings for the test target. Added KIF as a target dependency.

It builds OK now. It built OK for you in XCode because you were building sample scheme, not sampleunittests

You still need to change 
```@interface sampleTests : XCTestCase```
to
```@interface sampleTests : KIFTestCase```
in order to use KIF methods. 